### PR TITLE
fix indentation after new line containing parentheses

### DIFF
--- a/pest-mode.el
+++ b/pest-mode.el
@@ -106,10 +106,8 @@
                              (re-search-backward "|" paren-start-pos t)))))
         (unless (= depth 0)
           (setq indent base)
-          (if (looking-at "\\s)")
-              (setq indent (- base 4))
-            (if (null rule-sep)
-              (setq indent (+ 2 base)))))))
+          (when (looking-at "\\s)")
+            (setq indent (- base 4))))))
     indent))
 
 


### PR DESCRIPTION
Hi,

The current indentation of Pest is computed incorrectly if some lines in the rule contain parentheses.

For example, in the following, the indentation is incorrect after the line `(object | data)* ~`:

```pest
// A Yul object.
object = {
      OBJECT ~
      string_literal ~
      "{" ~
      code ~
      (object | data)* ~
    "}"        // This line is indented wrongly.
}
```

I fixed this issue in this PR so that the new indentation becomes:

```pest
// A Yul object.
object = {
    OBJECT ~
    string_literal ~
    "{" ~
    code ~
    (object | data)* ~
    "}"
}
```

Can you take a look at this PR and merge it if possible?

Thanks!