### PR TITLE
allow blank character in rule regexp

### DIFF
--- a/pest-mode.el
+++ b/pest-mode.el
@@ -117,7 +117,11 @@
 (defvar pest--rule-regexp (rx bol
                               (group (+ (or alpha "_") (* (or (char alnum) "_"))))
                               (* blank)
-                              "=" (* blank) (or "_{" "@{" "!{" "${" "{")))
+                              "=" (* blank) (or (and "_" (* blank) "{")
+                                                (and "@" (* blank) "{")
+                                                (and "!" (* blank) "{")
+                                                (and "$" (* blank) "{")
+                                                "{")))
 
 (defun pest--match-rule-name ()
   "Extract the rule name from last match."


### PR DESCRIPTION
Hi,

This PR allows adding whitespace to match the sequence `$ {`, `_ {`, `_  {`, `_    {`,,... since all of them are valid Pest syntax.

Can you review and merge it if possible?
Thanks!